### PR TITLE
capture matching endpoints update

### DIFF
--- a/__tests__/integration/capture/capture.spec.js
+++ b/__tests__/integration/capture/capture.spec.js
@@ -284,6 +284,9 @@ describe('/captures', () => {
         .set('Accept', 'application/json')
         .expect(200);
 
+      const tree = await knex('tree').select().where({ id: tree1.id });
+      expect(tree[0].latest_capture_id).eql(captureId);
+
       expect(res.body).to.include({
         image_url: capture2.image_url,
         planting_organization_id: capture2.planting_organization_id,

--- a/server/models/Capture.js
+++ b/server/models/Capture.js
@@ -1,7 +1,8 @@
-const knex = require('../infra/database/knex');
-const CaptureRepository = require('../repositories/CaptureRepository');
-const { DomainEventTypes } = require('../utils/enums');
 const DomainEvent = require('./DomainEvent');
+const knex = require('../infra/database/knex');
+const { DomainEventTypes } = require('../utils/enums');
+const TreeRepository = require('../repositories/TreeRepository');
+const CaptureRepository = require('../repositories/CaptureRepository');
 
 class Capture {
   constructor(session) {
@@ -242,6 +243,15 @@ class Capture {
   }
 
   async updateCapture(captureObject) {
+    if (captureObject.tree_id) {
+      const treeRepository = new TreeRepository(this._session);
+      await treeRepository.update({
+        id: captureObject.tree_id,
+        latest_capture_id: captureObject.id,
+        updated_at: new Date().toISOString(),
+      });
+    }
+
     const updatedCapture = await this._captureRepository.update({
       ...captureObject,
       updated_at: new Date().toISOString(),


### PR DESCRIPTION
@gwynndp . Update both the tree and capture tables for each of the capture-matching endpoints

update_tree with latest_capture_id will also update the capture
adding a new tree will update the capture tree_id as well
updating a capture with tree_id will also update the tree's latest_capture_id

