### PR TITLE
fix: already on database folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ To create the necessary tables for your application, run db-migrate below.
 
 ```bash
 cd database/
-db-migrate up --env dev --sql-file --migrations-dir=database/migrations --config=database/database.json
+db-migrate up --env dev --sql-file --migrations-dir=migrations --config=database.json
 ```
 
 If you have not installed db-migrate globally, you can run:


### PR DESCRIPTION
# Description
we are in the database folder so; we do not need to define a database path.
![tree-tracker-api-readme](https://github.com/Greenstand/treetracker-api/assets/54142355/71c791f7-674d-48dd-a808-4c71b7bf9972)
